### PR TITLE
Fix all ESLint errors and warnings (2020-07-07T13:44:22)

### DIFF
--- a/container/src/components/NotificationStorage/index.test.tsx
+++ b/container/src/components/NotificationStorage/index.test.tsx
@@ -12,7 +12,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <NotificationStorage {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("NotificationStorage", () => {

--- a/container/src/components/Scoreboard/AddPlayerForm/__snapshots__/index.test.tsx.snap
+++ b/container/src/components/Scoreboard/AddPlayerForm/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/AddPlayerForm compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <AddPlayerForm
+    add={[MockFunction]}
+  >
+    <div
+      className="add-player-form"
+    >
+      <form
+        onSubmit={[Function]}
+      >
+        <input
+          maxLength={64}
+          onChange={[Function]}
+          placeholder="Enter a player's name"
+          type="text"
+          value=""
+        />
+        <button
+          type="submit"
+        >
+          Add Player
+        </button>
+      </form>
+    </div>
+  </AddPlayerForm>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/AddPlayerForm/index.test.tsx
+++ b/container/src/components/Scoreboard/AddPlayerForm/index.test.tsx
@@ -10,6 +10,11 @@ import { setupStore } from "Utils/testUtils";
 jest.mock("Store/scoreboard/player/actions");
 mockdate.set(1576071902);
 const fakeDate = "1/19/1970";
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => "43802ca3-f4e1-4233-a101-eea29eeaf388"),
+  };
+});
 
 function setupWrapper(mockStore = setupStore(), props = { add }): ReactWrapper {
   return mount(
@@ -47,7 +52,11 @@ describe("Scoreboard/AddPlayerForm", () => {
         // do nothing.
       },
     });
-    expect(add).toHaveBeenCalledWith(expect.any(String), "Hello W", fakeDate);
+    expect(add).toHaveBeenCalledWith(
+      "43802ca3-f4e1-4233-a101-eea29eeaf388",
+      "Hello W",
+      fakeDate
+    );
     expect(add).toHaveBeenCalledTimes(1);
   });
 });

--- a/container/src/components/Scoreboard/AddPlayerForm/index.test.tsx
+++ b/container/src/components/Scoreboard/AddPlayerForm/index.test.tsx
@@ -16,7 +16,7 @@ function setupWrapper(mockStore = setupStore(), props = { add }): ReactWrapper {
     <Provider store={mockStore}>
       <AddPlayerForm {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/AddPlayerForm", () => {
@@ -27,9 +27,9 @@ describe("Scoreboard/AddPlayerForm", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should handle <input> onChange", () => {
     wrapper

--- a/container/src/components/Scoreboard/Header/Stats.test.tsx
+++ b/container/src/components/Scoreboard/Header/Stats.test.tsx
@@ -5,10 +5,12 @@ import { mount, ReactWrapper } from "enzyme";
 import Stats from "Components/Scoreboard/Header/Stats";
 import { setupStore, multiToEqual } from "Utils/testUtils";
 import { playerCountSelector, scoreCountSelector } from "Utils/selectors";
+
+import { AppState } from "Store/index";
 import { StatsProps } from "Containers/Scoreboard/Header/Stats";
 
 // Pass down the props from mock store to wrapper
-function setupProps(state = setupStore().getState()): StatsProps {
+function setupProps(state = setupStore().getState() as AppState): StatsProps {
   return {
     playerCount: playerCountSelector(state),
     scoreCount: scoreCountSelector(state),
@@ -23,7 +25,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Stats {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Stats", () => {
@@ -34,10 +36,11 @@ describe("Scoreboard/Stats", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
+  /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "multiToEqual"] }] */
   it("should display player and point count", () => {
     function mapRowColumns(index: number): string[] {
       return wrapper

--- a/container/src/components/Scoreboard/Header/Stopwatch.test.tsx
+++ b/container/src/components/Scoreboard/Header/Stopwatch.test.tsx
@@ -6,16 +6,20 @@ import mockdate from "mockdate";
 
 import { tick, toggle, reset } from "Store/scoreboard/stopwatch/actions";
 import Stopwatch from "Components/Scoreboard/Header/Stopwatch";
-import { StopwatchProps } from "Containers/Scoreboard/Header/Stopwatch";
 import { setupStore } from "Utils/testUtils";
 import { isRunningSelector, elaspedTimeSelector } from "Utils/selectors";
+
+import { AppState } from "Store/index";
+import { StopwatchProps } from "Containers/Scoreboard/Header/Stopwatch";
 
 jest.mock("Store/scoreboard/stopwatch/actions");
 jest.useFakeTimers();
 mockdate.set(1574086940640);
 
 // Pass down the props from mock store to wrapper
-function setupProps(state = setupStore().getState()): StopwatchProps {
+function setupProps(
+  state = setupStore().getState() as AppState
+): StopwatchProps {
   return {
     isRunning: isRunningSelector(state),
     elapsedTime: elaspedTimeSelector(state),
@@ -33,7 +37,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Stopwatch {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Stopwatch", () => {
@@ -45,9 +49,9 @@ describe("Scoreboard/Stopwatch", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it('should display time in "m:s.ms" format', () => {
     expect(wrapper.find("div.stopwatch-time").length).toEqual(1);

--- a/container/src/components/Scoreboard/Header/__snapshots__/Stats.test.tsx.snap
+++ b/container/src/components/Scoreboard/Header/__snapshots__/Stats.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Stats compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Stats
+    playerCount={2}
+    scoreCount={14}
+  >
+    <table
+      className="stats"
+    >
+      <tbody>
+        <tr>
+          <td>
+            Players:
+          </td>
+          <td>
+            2
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Total Points:
+          </td>
+          <td>
+            14
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Stats>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/Header/__snapshots__/Stopwatch.test.tsx.snap
+++ b/container/src/components/Scoreboard/Header/__snapshots__/Stopwatch.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Stopwatch compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Stopwatch
+    elapsedTime={0}
+    isRunning={false}
+    reset={[MockFunction]}
+    tick={[MockFunction]}
+    toggle={[MockFunction]}
+  >
+    <div
+      className="stopwatch"
+    >
+      <h2>
+        Stopwatch
+      </h2>
+      <div
+        className="stopwatch-time"
+      >
+        00:00.00
+      </div>
+      <button
+        onClick={[Function]}
+      >
+        Start
+      </button>
+      <button
+        onClick={[Function]}
+      >
+        Reset
+      </button>
+    </div>
+  </Stopwatch>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/Header/__snapshots__/index.test.tsx.snap
+++ b/container/src/components/Scoreboard/Header/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Header compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Header>
+    <div
+      className="header"
+    >
+      <Connect(Stats)>
+        <Stats
+          dispatch={[Function]}
+          playerCount={2}
+          scoreCount={14}
+        >
+          <table
+            className="stats"
+          >
+            <tbody>
+              <tr>
+                <td>
+                  Players:
+                </td>
+                <td>
+                  2
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Total Points:
+                </td>
+                <td>
+                  14
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </Stats>
+      </Connect(Stats)>
+      <h1>
+        Scoreboard
+      </h1>
+      <Connect(Stopwatch)>
+        <Stopwatch
+          elapsedTime={0}
+          isRunning={false}
+          reset={[Function]}
+          tick={[Function]}
+          toggle={[Function]}
+        >
+          <div
+            className="stopwatch"
+          >
+            <h2>
+              Stopwatch
+            </h2>
+            <div
+              className="stopwatch-time"
+            >
+              00:00.00
+            </div>
+            <button
+              onClick={[Function]}
+            >
+              Start
+            </button>
+            <button
+              onClick={[Function]}
+            >
+              Reset
+            </button>
+          </div>
+        </Stopwatch>
+      </Connect(Stopwatch)>
+    </div>
+  </Header>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/Header/index.test.tsx
+++ b/container/src/components/Scoreboard/Header/index.test.tsx
@@ -10,7 +10,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <Header {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Header", () => {
@@ -22,7 +22,6 @@ describe("Scoreboard/Header", () => {
   });
 
   test("compare to the last snapshot", () => {
-    // expect(wrapper).toMatchSnapshot();
-    expect(wrapper);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/container/src/components/Scoreboard/PlayerDetail/ThemeSwitch.test.tsx
+++ b/container/src/components/Scoreboard/PlayerDetail/ThemeSwitch.test.tsx
@@ -5,14 +5,18 @@ import { mount, ReactWrapper } from "enzyme";
 
 import { toggle } from "Store/scoreboard/theme/actions";
 import ThemeSwitch from "Components/Scoreboard/PlayerDetail/ThemeSwitch";
-import { ThemeSwitchProps } from "Containers/Scoreboard/PlayerDetail/ThemeSwitch";
 import { setupStore } from "Utils/testUtils";
 import { isLightModeSelector } from "Utils/selectors";
+
+import { AppState } from "Store/index";
+import { ThemeSwitchProps } from "Containers/Scoreboard/PlayerDetail/ThemeSwitch";
 
 jest.mock("Store/scoreboard/theme/actions");
 
 // Pass down the props from mock store to wrapper
-function setupProps(state = setupStore().getState()): ThemeSwitchProps {
+function setupProps(
+  state = setupStore().getState() as AppState
+): ThemeSwitchProps {
   return {
     isLightMode: isLightModeSelector(state),
     toggle,
@@ -27,7 +31,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <ThemeSwitch {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/ThemeSwitch", () => {
@@ -39,9 +43,9 @@ describe("Scoreboard/ThemeSwitch", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it('should display "Dark" by default', () => {
     expect(wrapper.find("button").at(0).text()).toEqual("Dark");

--- a/container/src/components/Scoreboard/PlayerDetail/__snapshots__/ThemeSwitch.test.tsx.snap
+++ b/container/src/components/Scoreboard/PlayerDetail/__snapshots__/ThemeSwitch.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/ThemeSwitch compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <ThemeSwitch
+    isLightMode={false}
+    toggle={[MockFunction]}
+  >
+    <button
+      className="mode-switch"
+      onClick={[MockFunction]}
+    >
+      Dark
+    </button>
+  </ThemeSwitch>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/PlayerDetail/__snapshots__/index.test.tsx.snap
+++ b/container/src/components/Scoreboard/PlayerDetail/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/PlayerDetail compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <PlayerDetail>
+    <div
+      className="player-detail"
+    >
+      <p>
+        *Click on a player to see more details.
+      </p>
+      <Connect(ThemeSwitch)>
+        <ThemeSwitch
+          isLightMode={false}
+          toggle={[Function]}
+        >
+          <button
+            className="mode-switch"
+            onClick={[Function]}
+          >
+            Dark
+          </button>
+        </ThemeSwitch>
+      </Connect(ThemeSwitch)>
+    </div>
+  </PlayerDetail>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/PlayerDetail/index.test.tsx
+++ b/container/src/components/Scoreboard/PlayerDetail/index.test.tsx
@@ -4,12 +4,16 @@ import { Store } from "redux";
 import { mount, ReactWrapper } from "enzyme";
 
 import PlayerDetail from "Components/Scoreboard/PlayerDetail/";
-import { PlayerDetaiProps } from "Containers/Scoreboard/PlayerDetail";
 import { setupStore, matchMultiLength, multiToEqual } from "Utils/testUtils";
 import { playerDetailSelector } from "Utils/selectors";
 
+import { AppState } from "Store/index";
+import { PlayerDetaiProps } from "Containers/Scoreboard/PlayerDetail";
+
 // Pass down the props from mock store to wrapper
-function setupProps(state = setupStore().getState()): PlayerDetaiProps {
+function setupProps(
+  state = setupStore().getState() as AppState
+): PlayerDetaiProps {
   return {
     player: playerDetailSelector(state),
   };
@@ -23,7 +27,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <PlayerDetail {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/PlayerDetail", () => {
@@ -35,9 +39,9 @@ describe("Scoreboard/PlayerDetail", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should display tips by default", () => {
     expect(wrapper.find("p").at(0).text()).toEqual(

--- a/container/src/components/Scoreboard/PlayerList/Player/Counter.test.tsx
+++ b/container/src/components/Scoreboard/PlayerList/Player/Counter.test.tsx
@@ -5,16 +5,18 @@ import mockdate from "mockdate";
 
 import { update } from "Store/scoreboard/player/actions";
 import Counter from "Components/Scoreboard/PlayerList/Player/Counter";
-import { CounterProps } from "Containers/Scoreboard/PlayerList/Player/Counter";
 import { setupStore } from "Utils/testUtils";
 import { playerListSelector } from "Utils/selectors";
+
+import { AppState } from "Store/index";
+import { CounterProps } from "Containers/Scoreboard/PlayerList/Player/Counter";
 
 jest.mock("Store/scoreboard/player/actions");
 mockdate.set(1576071902);
 const fakeDate = "1/19/1970";
 
 // Pass down the props from mock store to wrapper
-function setupProps(state = setupStore().getState()): CounterProps {
+function setupProps(state = setupStore().getState() as AppState): CounterProps {
   const { id, score } = playerListSelector(state)[0];
   return { id, score, update };
 }
@@ -27,7 +29,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Counter {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Counter", () => {
@@ -38,9 +40,9 @@ describe("Scoreboard/Counter", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should display score", () => {
     // The player at index 0 from setupStore() has a score of 10

--- a/container/src/components/Scoreboard/PlayerList/Player/Crown.test.tsx
+++ b/container/src/components/Scoreboard/PlayerList/Player/Crown.test.tsx
@@ -4,13 +4,15 @@ import { Store } from "redux";
 import { mount, ReactWrapper } from "enzyme";
 
 import Crown from "Components/Scoreboard/PlayerList/Player/Crown";
-import { CrownProps } from "Containers/Scoreboard/PlayerList/Player/Crown";
 import { setupStore } from "Utils/testUtils";
 import { playerListSelector, scoreListSelector } from "Utils/selectors";
 
+import { AppState } from "Store/index";
+import { CrownProps } from "Containers/Scoreboard/PlayerList/Player/Crown";
+
 // Pass down the props from mock store to wrapper
 function setupProps(
-  state = setupStore().getState(),
+  state = setupStore().getState() as AppState,
   index: number
 ): CrownProps {
   const score = playerListSelector(state)[index].score;
@@ -28,7 +30,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Crown {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Crown", () => {
@@ -40,9 +42,9 @@ describe("Scoreboard/Crown", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it('should have "crown" class by default', () => {
     expect(wrapper.find("svg.crown").length).toEqual(1);

--- a/container/src/components/Scoreboard/PlayerList/Player/__snapshots__/Counter.test.tsx.snap
+++ b/container/src/components/Scoreboard/PlayerList/Player/__snapshots__/Counter.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Counter compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Counter
+    id="1654A"
+    score={10}
+    update={[MockFunction]}
+  >
+    <div
+      className="counter"
+    >
+      <button
+        className="counter-action decrement"
+        onClick={[Function]}
+      >
+        -
+      </button>
+      <div
+        className="counter-score"
+      >
+        10
+      </div>
+      <button
+        className="counter-action increment"
+        onClick={[Function]}
+      >
+        +
+      </button>
+    </div>
+  </Counter>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/PlayerList/Player/__snapshots__/Crown.test.tsx.snap
+++ b/container/src/components/Scoreboard/PlayerList/Player/__snapshots__/Crown.test.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Crown compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Crown
+    hasCrown={false}
+  >
+    <svg
+      className="crown"
+      viewBox="0 0 44 35"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+        transform="translate(0 0.301727)"
+      />
+      <rect
+        height="3.07759"
+        transform="translate(6.56987 31.5603)"
+        width="30.4986"
+      />
+    </svg>
+  </Crown>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/PlayerList/Player/__snapshots__/index.test.tsx.snap
+++ b/container/src/components/Scoreboard/PlayerList/Player/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Player compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Player
+    id="1654A"
+    index={0}
+    isSelected={false}
+    name="Alpha"
+    remove={[MockFunction]}
+    select={[MockFunction]}
+  >
+    <div
+      className="player"
+    >
+      <div
+        className="player-name"
+      >
+        <a
+          className="remove-player"
+          onClick={[Function]}
+        >
+          ✕
+        </a>
+        <Connect(Crown)
+          index={0}
+        >
+          <Crown
+            dispatch={[Function]}
+            hasCrown={true}
+            index={0}
+          >
+            <svg
+              className="crown has-crown"
+              viewBox="0 0 44 35"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+                transform="translate(0 0.301727)"
+              />
+              <rect
+                height="3.07759"
+                transform="translate(6.56987 31.5603)"
+                width="30.4986"
+              />
+            </svg>
+          </Crown>
+        </Connect(Crown)>
+        <span
+          onClick={[Function]}
+        >
+          Alpha
+        </span>
+      </div>
+      <Connect(Counter)
+        index={0}
+      >
+        <Counter
+          id="1654A"
+          index={0}
+          score={10}
+          update={[Function]}
+        >
+          <div
+            className="counter"
+          >
+            <button
+              className="counter-action decrement"
+              onClick={[Function]}
+            >
+              -
+            </button>
+            <div
+              className="counter-score"
+            >
+              10
+            </div>
+            <button
+              className="counter-action increment"
+              onClick={[Function]}
+            >
+              +
+            </button>
+          </div>
+        </Counter>
+      </Connect(Counter)>
+    </div>
+  </Player>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/PlayerList/Player/index.test.tsx
+++ b/container/src/components/Scoreboard/PlayerList/Player/index.test.tsx
@@ -5,14 +5,16 @@ import { mount, ReactWrapper } from "enzyme";
 
 import { remove, select } from "Store/scoreboard/player/actions";
 import Player from "Components/Scoreboard/PlayerList/Player/index";
-import { PlayerProps } from "Containers/Scoreboard/PlayerList/Player";
 import { setupStore, matchMultiLength } from "Utils/testUtils";
 import { playerListSelector } from "Utils/selectors";
+
+import { AppState } from "Store/index";
+import { PlayerProps } from "Containers/Scoreboard/PlayerList/Player";
 
 jest.mock("Store/scoreboard/player/actions");
 
 // Pass down the props from mock store to wrapper
-function setupProps(state = setupStore().getState()): PlayerProps {
+function setupProps(state = setupStore().getState() as AppState): PlayerProps {
   const { id, name, isSelected } = playerListSelector(state)[0];
   return {
     index: 0,
@@ -32,7 +34,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Player {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Player", () => {
@@ -44,9 +46,9 @@ describe("Scoreboard/Player", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should display player name", () => {
     // Name of the player at index 0, because we passed 0 to setupWrapper
@@ -76,6 +78,7 @@ describe("Scoreboard/Player", () => {
       ],
     });
     wrapper = setupWrapper(mockStore);
+    /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "matchMultiLength"] }] */
     matchMultiLength(wrapper, [
       ["div.player.player-selected", 1],
       ["a.remove-player.remove-player-selected", 1],

--- a/container/src/components/Scoreboard/PlayerList/__snapshots__/index.test.tsx.snap
+++ b/container/src/components/Scoreboard/PlayerList/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,223 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/PlayerList compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <PlayerList
+    playerList={
+      Array [
+        Object {
+          "created": "11/21/2016",
+          "id": "1654A",
+          "isSelected": false,
+          "name": "Alpha",
+          "score": 10,
+          "updated": "06/12/2018",
+        },
+        Object {
+          "created": "11/8/2016",
+          "id": "1654B",
+          "isSelected": false,
+          "name": "Beta",
+          "score": 4,
+          "updated": "11/9/2017",
+        },
+      ]
+    }
+  >
+    <div
+      className="players"
+    >
+      <Connect(Player)
+        index={0}
+        key="1654A"
+      >
+        <Player
+          id="1654A"
+          index={0}
+          isSelected={false}
+          name="Alpha"
+          remove={[Function]}
+          select={[Function]}
+        >
+          <div
+            className="player"
+          >
+            <div
+              className="player-name"
+            >
+              <a
+                className="remove-player"
+                onClick={[Function]}
+              >
+                ✕
+              </a>
+              <Connect(Crown)
+                index={0}
+              >
+                <Crown
+                  dispatch={[Function]}
+                  hasCrown={true}
+                  index={0}
+                >
+                  <svg
+                    className="crown has-crown"
+                    viewBox="0 0 44 35"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+                      transform="translate(0 0.301727)"
+                    />
+                    <rect
+                      height="3.07759"
+                      transform="translate(6.56987 31.5603)"
+                      width="30.4986"
+                    />
+                  </svg>
+                </Crown>
+              </Connect(Crown)>
+              <span
+                onClick={[Function]}
+              >
+                Alpha
+              </span>
+            </div>
+            <Connect(Counter)
+              index={0}
+            >
+              <Counter
+                id="1654A"
+                index={0}
+                score={10}
+                update={[Function]}
+              >
+                <div
+                  className="counter"
+                >
+                  <button
+                    className="counter-action decrement"
+                    onClick={[Function]}
+                  >
+                    -
+                  </button>
+                  <div
+                    className="counter-score"
+                  >
+                    10
+                  </div>
+                  <button
+                    className="counter-action increment"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </div>
+              </Counter>
+            </Connect(Counter)>
+          </div>
+        </Player>
+      </Connect(Player)>
+      <Connect(Player)
+        index={1}
+        key="1654B"
+      >
+        <Player
+          id="1654B"
+          index={1}
+          isSelected={false}
+          name="Beta"
+          remove={[Function]}
+          select={[Function]}
+        >
+          <div
+            className="player"
+          >
+            <div
+              className="player-name"
+            >
+              <a
+                className="remove-player"
+                onClick={[Function]}
+              >
+                ✕
+              </a>
+              <Connect(Crown)
+                index={1}
+              >
+                <Crown
+                  dispatch={[Function]}
+                  hasCrown={false}
+                  index={1}
+                >
+                  <svg
+                    className="crown"
+                    viewBox="0 0 44 35"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+                      transform="translate(0 0.301727)"
+                    />
+                    <rect
+                      height="3.07759"
+                      transform="translate(6.56987 31.5603)"
+                      width="30.4986"
+                    />
+                  </svg>
+                </Crown>
+              </Connect(Crown)>
+              <span
+                onClick={[Function]}
+              >
+                Beta
+              </span>
+            </div>
+            <Connect(Counter)
+              index={1}
+            >
+              <Counter
+                id="1654B"
+                index={1}
+                score={4}
+                update={[Function]}
+              >
+                <div
+                  className="counter"
+                >
+                  <button
+                    className="counter-action decrement"
+                    onClick={[Function]}
+                  >
+                    -
+                  </button>
+                  <div
+                    className="counter-score"
+                  >
+                    4
+                  </div>
+                  <button
+                    className="counter-action increment"
+                    onClick={[Function]}
+                  >
+                    +
+                  </button>
+                </div>
+              </Counter>
+            </Connect(Counter)>
+          </div>
+        </Player>
+      </Connect(Player)>
+    </div>
+  </PlayerList>
+</Provider>
+`;

--- a/container/src/components/Scoreboard/PlayerList/index.test.tsx
+++ b/container/src/components/Scoreboard/PlayerList/index.test.tsx
@@ -3,12 +3,16 @@ import { Provider } from "react-redux";
 import { mount, ReactWrapper } from "enzyme";
 
 import PlayerList from "Components/Scoreboard/PlayerList/";
-import { PlayerListProps } from "Containers/Scoreboard/PlayerList";
 import { setupStore } from "Utils/testUtils";
 import { playerListSelector } from "Utils/selectors";
 
+import { AppState } from "Store/index";
+import { PlayerListProps } from "Containers/Scoreboard/PlayerList";
+
 // Pass down the props from mock store to wrapper
-function setupProps(state = setupStore().getState()): PlayerListProps {
+function setupProps(
+  state = setupStore().getState() as AppState
+): PlayerListProps {
   return {
     playerList: playerListSelector(state),
   };
@@ -22,7 +26,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <PlayerList {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/PlayerList", () => {
@@ -34,7 +38,6 @@ describe("Scoreboard/PlayerList", () => {
   });
 
   test("compare to the last snapshot", () => {
-    // expect(wrapper).toMatchSnapshot();
-    expect(wrapper);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/container/src/components/Scoreboard/index.test.tsx
+++ b/container/src/components/Scoreboard/index.test.tsx
@@ -13,7 +13,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <Scoreboard {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard", () => {

--- a/container/src/components/common/Notification/index.test.tsx
+++ b/container/src/components/common/Notification/index.test.tsx
@@ -17,7 +17,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Notification {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Notification", () => {

--- a/container/src/store/scoreboard/stopwatch/reducer.test.ts
+++ b/container/src/store/scoreboard/stopwatch/reducer.test.ts
@@ -10,6 +10,7 @@ import { StopwatchActions } from "Store/scoreboard/stopwatch/actions";
 mockdate.set(1574086940640);
 
 describe("scoreboard/stopwatchReducer", () => {
+  /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "handleStopwatchTest"] }] */
   const handleStopwatchTest = (
     action: AnyAction,
     [isRunning, previousTime, elapsedTime]: [boolean, number, number],

--- a/default/src/components/NotificationStorage/index.test.tsx
+++ b/default/src/components/NotificationStorage/index.test.tsx
@@ -12,7 +12,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <NotificationStorage {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("NotificationStorage", () => {

--- a/default/src/components/Scoreboard/AddPlayerForm/__snapshots__/index.test.tsx.snap
+++ b/default/src/components/Scoreboard/AddPlayerForm/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/AddPlayerForm compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <AddPlayerForm>
+    <div
+      className="add-player-form"
+    >
+      <form
+        onSubmit={[Function]}
+      >
+        <input
+          maxLength={64}
+          onChange={[Function]}
+          placeholder="Enter a player's name"
+          type="text"
+          value=""
+        />
+        <button
+          type="submit"
+        >
+          Add Player
+        </button>
+      </form>
+    </div>
+  </AddPlayerForm>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/AddPlayerForm/index.test.tsx
+++ b/default/src/components/Scoreboard/AddPlayerForm/index.test.tsx
@@ -9,13 +9,18 @@ import { setupStore } from "Utils/testUtils";
 
 mockdate.set(1576071902);
 const fakeDate = "1/19/1970";
+jest.mock("uuid", () => {
+  return {
+    v4: jest.fn(() => "43802ca3-f4e1-4233-a101-eea29eeaf388"),
+  };
+});
 
 function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
   return mount(
     <Provider store={mockStore}>
       <AddPlayerForm {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/AddPlayerForm", () => {
@@ -29,9 +34,9 @@ describe("Scoreboard/AddPlayerForm", () => {
     wrapper = setupWrapper(mockStore, {});
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should handle <input> onChange", () => {
     wrapper
@@ -52,7 +57,7 @@ describe("Scoreboard/AddPlayerForm", () => {
     expect(mockStore.dispatch).toHaveBeenCalledWith({
       type: "player/add",
       payload: {
-        id: expect.any(String),
+        id: "43802ca3-f4e1-4233-a101-eea29eeaf388",
         name: "Hello W",
         date: fakeDate,
       },

--- a/default/src/components/Scoreboard/AddPlayerForm/index.tsx
+++ b/default/src/components/Scoreboard/AddPlayerForm/index.tsx
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import getCurrentDate from "Utils/getCurrentDate";
 
-const AddPlayerForm: React.FC<{}> = () => {
+const AddPlayerForm: React.FC<Record<string, unknown>> = () => {
   // State (local)
   const [value, setValue] = useState("");
 

--- a/default/src/components/Scoreboard/Header/Stats.test.tsx
+++ b/default/src/components/Scoreboard/Header/Stats.test.tsx
@@ -11,7 +11,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <Stats {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Stats", () => {
@@ -24,9 +24,9 @@ describe("Scoreboard/Stats", () => {
     wrapper = setupWrapper(mockStore, {});
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should display player and point count", () => {
     function mapRowColumns(index: number): string[] {
@@ -38,6 +38,7 @@ describe("Scoreboard/Stats", () => {
     }
     const firstRowColumns = mapRowColumns(0);
     const secondRowColumns = mapRowColumns(1);
+    /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "multiToEqual"] }] */
     multiToEqual([
       [firstRowColumns.length, 2],
       [firstRowColumns[0], "Players:"],

--- a/default/src/components/Scoreboard/Header/Stats.tsx
+++ b/default/src/components/Scoreboard/Header/Stats.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { AppState } from "Store/index";
 import { scoreCountSelector, playerCountSelector } from "Utils/selectors";
 
-const Stats: React.FC<{}> = () => {
+const Stats: React.FC<Record<string, unknown>> = () => {
   // State (redux)
   const scoreCount = useSelector((state: AppState) =>
     scoreCountSelector(state)

--- a/default/src/components/Scoreboard/Header/Stopwatch.test.tsx
+++ b/default/src/components/Scoreboard/Header/Stopwatch.test.tsx
@@ -15,7 +15,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <Stopwatch {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Stopwatch", () => {
@@ -29,9 +29,9 @@ describe("Scoreboard/Stopwatch", () => {
     wrapper = setupWrapper(mockStore, {});
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it('should display time in "m:s.ms" format', () => {
     expect(wrapper.find("div.stopwatch-time").length).toEqual(1);

--- a/default/src/components/Scoreboard/Header/Stopwatch.tsx
+++ b/default/src/components/Scoreboard/Header/Stopwatch.tsx
@@ -5,7 +5,7 @@ import { AppState } from "Store/index";
 import formatTime from "Utils/formatTime";
 import { isRunningSelector, elaspedTimeSelector } from "Utils/selectors";
 
-const Stopwatch: React.FC<{}> = () => {
+const Stopwatch: React.FC<Record<string, unknown>> = () => {
   // State (redux)
   const isRunning = useSelector((state: AppState) => isRunningSelector(state));
   const elapsedTime = useSelector((state: AppState) =>

--- a/default/src/components/Scoreboard/Header/__snapshots__/Stats.test.tsx.snap
+++ b/default/src/components/Scoreboard/Header/__snapshots__/Stats.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Stats compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Stats>
+    <table
+      className="stats"
+    >
+      <tbody>
+        <tr>
+          <td>
+            Players:
+          </td>
+          <td>
+            2
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Total Points:
+          </td>
+          <td>
+            14
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Stats>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/Header/__snapshots__/Stopwatch.test.tsx.snap
+++ b/default/src/components/Scoreboard/Header/__snapshots__/Stopwatch.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Stopwatch compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Stopwatch>
+    <div
+      className="stopwatch"
+    >
+      <h2>
+        Stopwatch
+      </h2>
+      <div
+        className="stopwatch-time"
+      >
+        00:00.00
+      </div>
+      <button
+        onClick={[Function]}
+      >
+        Start
+      </button>
+      <button
+        onClick={[Function]}
+      >
+        Reset
+      </button>
+    </div>
+  </Stopwatch>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/Header/__snapshots__/index.test.tsx.snap
+++ b/default/src/components/Scoreboard/Header/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Header compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Header>
+    <div
+      className="header"
+    >
+      <Stats>
+        <table
+          className="stats"
+        >
+          <tbody>
+            <tr>
+              <td>
+                Players:
+              </td>
+              <td>
+                2
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Total Points:
+              </td>
+              <td>
+                14
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </Stats>
+      <h1>
+        Scoreboard
+      </h1>
+      <Stopwatch>
+        <div
+          className="stopwatch"
+        >
+          <h2>
+            Stopwatch
+          </h2>
+          <div
+            className="stopwatch-time"
+          >
+            00:00.00
+          </div>
+          <button
+            onClick={[Function]}
+          >
+            Start
+          </button>
+          <button
+            onClick={[Function]}
+          >
+            Reset
+          </button>
+        </div>
+      </Stopwatch>
+    </div>
+  </Header>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/Header/index.test.tsx
+++ b/default/src/components/Scoreboard/Header/index.test.tsx
@@ -10,7 +10,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <Header {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Header", () => {
@@ -22,7 +22,6 @@ describe("Scoreboard/Header", () => {
   });
 
   test("compare to the last snapshot", () => {
-    // expect(wrapper).toMatchSnapshot();
-    expect(wrapper);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/default/src/components/Scoreboard/PlayerDetail/ThemeSwitch.test.tsx
+++ b/default/src/components/Scoreboard/PlayerDetail/ThemeSwitch.test.tsx
@@ -11,7 +11,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <ThemeSwitch {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/ThemeSwitch", () => {
@@ -25,9 +25,9 @@ describe("Scoreboard/ThemeSwitch", () => {
     wrapper = setupWrapper(mockStore);
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it('should display "Dark" by default', () => {
     expect(wrapper.find("button").at(0).text()).toEqual("Dark");

--- a/default/src/components/Scoreboard/PlayerDetail/ThemeSwitch.tsx
+++ b/default/src/components/Scoreboard/PlayerDetail/ThemeSwitch.tsx
@@ -5,7 +5,7 @@ import { AppState } from "Store/index";
 import toggleBodyClass from "Utils/toggleBodyClass";
 import { isLightModeSelector } from "Utils/selectors";
 
-const ThemeSwitch: React.FC<{}> = () => {
+const ThemeSwitch: React.FC<Record<string, unknown>> = () => {
   // State (redux)
   const isLightMode = useSelector((state: AppState) =>
     isLightModeSelector(state)

--- a/default/src/components/Scoreboard/PlayerDetail/__snapshots__/ThemeSwitch.test.tsx.snap
+++ b/default/src/components/Scoreboard/PlayerDetail/__snapshots__/ThemeSwitch.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/ThemeSwitch compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Memo(ThemeSwitch)>
+    <button
+      className="mode-switch"
+      onClick={[Function]}
+    >
+      Dark
+    </button>
+  </Memo(ThemeSwitch)>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/PlayerDetail/__snapshots__/index.test.tsx.snap
+++ b/default/src/components/Scoreboard/PlayerDetail/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/PlayerDetail compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <PlayerDetail>
+    <div
+      className="player-detail"
+    >
+      <p>
+        *Click on a player to see more details.
+      </p>
+      <Memo(ThemeSwitch)>
+        <button
+          className="mode-switch"
+          onClick={[Function]}
+        >
+          Dark
+        </button>
+      </Memo(ThemeSwitch)>
+    </div>
+  </PlayerDetail>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/PlayerDetail/index.test.tsx
+++ b/default/src/components/Scoreboard/PlayerDetail/index.test.tsx
@@ -11,7 +11,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <PlayerDetail {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/PlayerDetail", () => {
@@ -25,9 +25,9 @@ describe("Scoreboard/PlayerDetail", () => {
     wrapper = setupWrapper(mockStore, {});
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should display tips by default", () => {
     expect(wrapper.find("p").at(0).text()).toEqual(

--- a/default/src/components/Scoreboard/PlayerDetail/index.tsx
+++ b/default/src/components/Scoreboard/PlayerDetail/index.tsx
@@ -5,7 +5,7 @@ import { AppState } from "Store/index";
 import ThemeSwitch from "./ThemeSwitch";
 import { playerDetailSelector } from "Utils/selectors";
 
-const PlayerDetail: React.FC<{}> = () => {
+const PlayerDetail: React.FC<Record<string, unknown>> = () => {
   // State (redux)
   const player = useSelector((state: AppState) => playerDetailSelector(state));
 

--- a/default/src/components/Scoreboard/PlayerList/Player/Counter.test.tsx
+++ b/default/src/components/Scoreboard/PlayerList/Player/Counter.test.tsx
@@ -18,7 +18,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Counter {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Counter", () => {
@@ -32,9 +32,9 @@ describe("Scoreboard/Counter", () => {
     wrapper = setupWrapper(mockStore);
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should display score", () => {
     // The player at index 0 from setupStore() has a score of 10

--- a/default/src/components/Scoreboard/PlayerList/Player/Crown.test.tsx
+++ b/default/src/components/Scoreboard/PlayerList/Player/Crown.test.tsx
@@ -14,7 +14,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Crown {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Crown", () => {
@@ -26,9 +26,9 @@ describe("Scoreboard/Crown", () => {
     wrapper = setupWrapper();
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it('should have "crown" class by default', () => {
     expect(wrapper.find("svg.crown").length).toEqual(1);

--- a/default/src/components/Scoreboard/PlayerList/Player/__snapshots__/Counter.test.tsx.snap
+++ b/default/src/components/Scoreboard/PlayerList/Player/__snapshots__/Counter.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Counter compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Memo(Counter)
+    index={0}
+  >
+    <div
+      className="counter"
+    >
+      <button
+        className="counter-action decrement"
+        onClick={[Function]}
+      >
+        -
+      </button>
+      <div
+        className="counter-score"
+      >
+        10
+      </div>
+      <button
+        className="counter-action increment"
+        onClick={[Function]}
+      >
+        +
+      </button>
+    </div>
+  </Memo(Counter)>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/PlayerList/Player/__snapshots__/Crown.test.tsx.snap
+++ b/default/src/components/Scoreboard/PlayerList/Player/__snapshots__/Crown.test.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Crown compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Memo(Crown)
+    index={1}
+  >
+    <svg
+      className="crown"
+      viewBox="0 0 44 35"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+        transform="translate(0 0.301727)"
+      />
+      <rect
+        height="3.07759"
+        transform="translate(6.56987 31.5603)"
+        width="30.4986"
+      />
+    </svg>
+  </Memo(Crown)>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/PlayerList/Player/__snapshots__/index.test.tsx.snap
+++ b/default/src/components/Scoreboard/PlayerList/Player/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/Player compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [MockFunction],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <Memo(Player)
+    index={0}
+  >
+    <div
+      className="player"
+    >
+      <div
+        className="player-name"
+      >
+        <a
+          className="remove-player"
+          onClick={[Function]}
+        >
+          ✕
+        </a>
+        <Memo(Crown)
+          index={0}
+        >
+          <svg
+            className="crown has-crown"
+            viewBox="0 0 44 35"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+              transform="translate(0 0.301727)"
+            />
+            <rect
+              height="3.07759"
+              transform="translate(6.56987 31.5603)"
+              width="30.4986"
+            />
+          </svg>
+        </Memo(Crown)>
+        <span
+          onClick={[Function]}
+        >
+          Alpha
+        </span>
+      </div>
+      <Memo(Counter)
+        index={0}
+      >
+        <div
+          className="counter"
+        >
+          <button
+            className="counter-action decrement"
+            onClick={[Function]}
+          >
+            -
+          </button>
+          <div
+            className="counter-score"
+          >
+            10
+          </div>
+          <button
+            className="counter-action increment"
+            onClick={[Function]}
+          >
+            +
+          </button>
+        </div>
+      </Memo(Counter)>
+    </div>
+  </Memo(Player)>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/PlayerList/Player/index.test.tsx
+++ b/default/src/components/Scoreboard/PlayerList/Player/index.test.tsx
@@ -14,7 +14,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Player {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/Player", () => {
@@ -28,9 +28,9 @@ describe("Scoreboard/Player", () => {
     wrapper = setupWrapper(mockStore);
   });
 
-  // test("compare to the last snapshot", () => {
-  //   expect(wrapper).toMatchSnapshot();
-  // });
+  test("compare to the last snapshot", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
 
   it("should display player name", () => {
     // Name of the player at index 0, because we passed 0 to setupWrapper
@@ -60,6 +60,7 @@ describe("Scoreboard/Player", () => {
       ],
     });
     wrapper = setupWrapper(mockStore);
+    /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "matchMultiLength"] }] */
     matchMultiLength(wrapper, [
       ["div.player.player-selected", 1],
       ["a.remove-player.remove-player-selected", 1],

--- a/default/src/components/Scoreboard/PlayerList/__snapshots__/index.test.tsx.snap
+++ b/default/src/components/Scoreboard/PlayerList/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Scoreboard/PlayerList compare to the last snapshot 1`] = `
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
+    }
+  }
+>
+  <PlayerList>
+    <div
+      className="players"
+    >
+      <Memo(Player)
+        index={0}
+        key="1654A"
+      >
+        <div
+          className="player"
+        >
+          <div
+            className="player-name"
+          >
+            <a
+              className="remove-player"
+              onClick={[Function]}
+            >
+              ✕
+            </a>
+            <Memo(Crown)
+              index={0}
+            >
+              <svg
+                className="crown has-crown"
+                viewBox="0 0 44 35"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+                  transform="translate(0 0.301727)"
+                />
+                <rect
+                  height="3.07759"
+                  transform="translate(6.56987 31.5603)"
+                  width="30.4986"
+                />
+              </svg>
+            </Memo(Crown)>
+            <span
+              onClick={[Function]}
+            >
+              Alpha
+            </span>
+          </div>
+          <Memo(Counter)
+            index={0}
+          >
+            <div
+              className="counter"
+            >
+              <button
+                className="counter-action decrement"
+                onClick={[Function]}
+              >
+                -
+              </button>
+              <div
+                className="counter-score"
+              >
+                10
+              </div>
+              <button
+                className="counter-action increment"
+                onClick={[Function]}
+              >
+                +
+              </button>
+            </div>
+          </Memo(Counter)>
+        </div>
+      </Memo(Player)>
+      <Memo(Player)
+        index={1}
+        key="1654B"
+      >
+        <div
+          className="player"
+        >
+          <div
+            className="player-name"
+          >
+            <a
+              className="remove-player"
+              onClick={[Function]}
+            >
+              ✕
+            </a>
+            <Memo(Crown)
+              index={1}
+            >
+              <svg
+                className="crown"
+                viewBox="0 0 44 35"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M26.7616 10.6207L21.8192 0L16.9973 10.5603C15.3699 14.1207 10.9096 15.2672 7.77534 12.9741L0 7.24138L6.56986 28.8448H37.0685L43.5781 7.72414L35.7425 13.0948C32.6685 15.2672 28.3288 14.0603 26.7616 10.6207Z"
+                  transform="translate(0 0.301727)"
+                />
+                <rect
+                  height="3.07759"
+                  transform="translate(6.56987 31.5603)"
+                  width="30.4986"
+                />
+              </svg>
+            </Memo(Crown)>
+            <span
+              onClick={[Function]}
+            >
+              Beta
+            </span>
+          </div>
+          <Memo(Counter)
+            index={1}
+          >
+            <div
+              className="counter"
+            >
+              <button
+                className="counter-action decrement"
+                onClick={[Function]}
+              >
+                -
+              </button>
+              <div
+                className="counter-score"
+              >
+                4
+              </div>
+              <button
+                className="counter-action increment"
+                onClick={[Function]}
+              >
+                +
+              </button>
+            </div>
+          </Memo(Counter)>
+        </div>
+      </Memo(Player)>
+    </div>
+  </PlayerList>
+</Provider>
+`;

--- a/default/src/components/Scoreboard/PlayerList/index.test.tsx
+++ b/default/src/components/Scoreboard/PlayerList/index.test.tsx
@@ -10,7 +10,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <PlayerList {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard/PlayerList", () => {
@@ -22,7 +22,6 @@ describe("Scoreboard/PlayerList", () => {
   });
 
   test("compare to the last snapshot", () => {
-    // expect(wrapper).toMatchSnapshot();
-    expect(wrapper);
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/default/src/components/Scoreboard/PlayerList/index.tsx
+++ b/default/src/components/Scoreboard/PlayerList/index.tsx
@@ -5,7 +5,7 @@ import { AppState } from "Store/index";
 import Player from "./Player";
 import { playerListSelector } from "Utils/selectors";
 
-const PlayerList: React.FC<{}> = () => {
+const PlayerList: React.FC<Record<string, unknown>> = () => {
   // State (redux)
   const playerList = useSelector((state: AppState) =>
     playerListSelector(state)

--- a/default/src/components/Scoreboard/index.test.tsx
+++ b/default/src/components/Scoreboard/index.test.tsx
@@ -13,7 +13,7 @@ function setupWrapper(mockStore = setupStore(), props = {}): ReactWrapper {
     <Provider store={mockStore}>
       <Scoreboard {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Scoreboard", () => {

--- a/default/src/components/common/Notification/index.test.tsx
+++ b/default/src/components/common/Notification/index.test.tsx
@@ -17,7 +17,7 @@ function setupWrapper(
     <Provider store={mockStore}>
       <Notification {...props} />
     </Provider>
-  );
+  ) as ReactWrapper;
 }
 
 describe("Notification", () => {

--- a/default/src/store/scoreboard/stopwatch/reducer.test.ts
+++ b/default/src/store/scoreboard/stopwatch/reducer.test.ts
@@ -10,6 +10,7 @@ import { StopwatchActions } from "Store/scoreboard/stopwatch/actions";
 mockdate.set(1574086940640);
 
 describe("scoreboard/stopwatch reducers", () => {
+  /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "handleStopwatchTest"] }] */
   const handleStopwatchTest = (
     action: AnyAction,
     [isRunning, previousTime, elapsedTime]: [boolean, number, number],

--- a/default/webpack.common.js
+++ b/default/webpack.common.js
@@ -66,8 +66,11 @@ module.exports = {
       // Analyze project structure and size of each chunk
       new BundleAnalyzerPlugin({
         // Static mode
-        analyzerMode: "static",        // Generate a HTML file with bundle report
-        reportFilename: path.resolve(__dirname, "coverage/webpack-bundle-analyzer/report.html")
+        analyzerMode: "static", // Generate a HTML file with bundle report
+        reportFilename: path.resolve(
+          __dirname,
+          "coverage/webpack-bundle-analyzer/report.html"
+        ),
 
         // Server mode
         // analyzerMode: "server",     // Start a HTTP server to show bundle report

--- a/default/yarn.lock
+++ b/default/yarn.lock
@@ -1484,17 +1484,6 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.5.0.tgz#d09f9ffb890d1b15a7ffa9975fae92eee05597c4"
-  integrity sha512-zGNOrVi5Wz0jcjUnFZ6QUD0MCox5hBuVwemGCew2qJzUX5xPoyR+0EzS5qD5qQXL/vnQ8Eu+nv03tpeFRwLrDg==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/types" "3.5.0"
-    "@typescript-eslint/typescript-estree" "3.5.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.6.0.tgz#0138152d66e3e53a6340f606793fb257bf2d76a1"
@@ -1527,11 +1516,6 @@
     "@typescript-eslint/typescript-estree" "3.6.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/types@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.5.0.tgz#4e3d2a2272268d8ec3e3e4a37152a64956682639"
-  integrity sha512-Dreqb5idi66VVs1QkbAwVeDmdJG+sDtofJtKwKCZXIaBsINuCN7Jv5eDIHrS0hFMMiOvPH9UuOs4splW0iZe4Q==
-
 "@typescript-eslint/types@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.6.0.tgz#4bd6eee55d2f9d35a4b36c4804be1880bf68f7bc"
@@ -1544,20 +1528,6 @@
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
-
-"@typescript-eslint/typescript-estree@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.5.0.tgz#dfc895db21a381b84f24c2a719f5bf9c600dcfdc"
-  integrity sha512-Na71ezI6QP5WVR4EHxwcBJgYiD+Sre9BZO5iJK2QhrmRPo/42+b0no/HZIrdD1sjghzlYv7t+7Jis05M1uMxQg==
-  dependencies:
-    "@typescript-eslint/types" "3.5.0"
-    "@typescript-eslint/visitor-keys" "3.5.0"
-    debug "^4.1.1"
     glob "^7.1.6"
     is-glob "^4.0.1"
     lodash "^4.17.15"
@@ -1577,13 +1547,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.5.0.tgz#73c1ea2582f814735e4afdc1cf6f5e3af78db60a"
-  integrity sha512-7cTp9rcX2sz9Z+zua9MCOX4cqp5rYyFD5o8LlbSpXrMTXoRdngTtotRZEkm8+FNMHPWYFhitFK+qt/brK8BVJQ==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/visitor-keys@3.6.0":
   version "3.6.0"


### PR DESCRIPTION
1. Fix no test assertions warning from using helper functions.
2. Fix unsafe assignment of `getState()`.
3. Fix unsafe return of type `ReactWrapper`.
4. Uncomment all snapshot tests.
5. Add the mock for `uuid`.
6. Fix the return type for React components with no props.