### PR TITLE
Add Node.js 10.x back to GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - name: Checkout
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [12.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
See https://github.com/zw627/react-redux-typescript-sass-boilerplates/issues/17.